### PR TITLE
Nix/Home Managerへ一括移行（WSL Ubuntu / Arch優先）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,29 @@
 # [dotfiles](https://github.com/isksss/dotfiles)
 
-`chezmoi` で管理している個人用 dotfiles です。
+Nix + Home Manager で管理している個人用 dotfiles です。
 
-## 使用ツール
+## 対応OS（優先）
 
-- [chezmoi](https://www.chezmoi.io/): dotfiles の配置と適用
-- [mise](https://github.com/jdx/mise): CLI ツールと言語ランタイムの管理
-
-```sh
-# miseをinstall
-curl https://mise.run | sh
-# dotfilesをセットアップ
-"$HOME/.local/bin/mise" exec chezmoi@latest -- "chezmoi init --apply isksss && mise up"
-```
+- WSL Ubuntu
+- Arch Linux
 
 ## セットアップ
 
-適用前に差分を確認してから反映します。
+### 1. Nix をインストール
+
+- 公式インストーラで `nix` を導入します。
+
+### 2. Home Manager を flake 経由で適用
 
 ```sh
-chezmoi diff
-chezmoi apply
-mise install
+# WSL Ubuntu
+nix run home-manager/master -- switch --flake .#ubuntu
+
+# Arch Linux
+nix run home-manager/master -- switch --flake .#arch
 ```
+
+## 管理方針
+
+- 旧運用の `chezmoi` / `mise` は利用しません。
+- ツールやランタイムは Nix で一元管理します。

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "dotfiles managed by Nix + Home Manager";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, home-manager, ... }:
+    let
+      mkHome = { system, username, homeDirectory, isWSL ? false }:
+        home-manager.lib.homeManagerConfiguration {
+          pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
+          extraSpecialArgs = { inherit isWSL; };
+          modules = [
+            ./nix/home/common.nix
+            ./nix/home/linux.nix
+            {
+              home.username = username;
+              home.homeDirectory = homeDirectory;
+            }
+          ];
+        };
+    in {
+      homeConfigurations = {
+        "ubuntu" = mkHome {
+          system = "x86_64-linux";
+          username = "${builtins.getEnv "USER"}";
+          homeDirectory = "${builtins.getEnv "HOME"}";
+          isWSL = true;
+        };
+
+        "arch" = mkHome {
+          system = "x86_64-linux";
+          username = "${builtins.getEnv "USER"}";
+          homeDirectory = "${builtins.getEnv "HOME"}";
+        };
+      };
+    };
+}

--- a/home/dot_bashrc
+++ b/home/dot_bashrc
@@ -1,3 +1,1 @@
-if command -v mise >/dev/null 2>&1; then
-	eval "$(mise activate bash)"
 fi

--- a/home/dot_config/zsh/dot_zshrc
+++ b/home/dot_config/zsh/dot_zshrc
@@ -41,14 +41,6 @@ fi
 alias re="exec ${SHELL} -l"
 alias cdrepo='cd "$(ghq list -p | fzf)"'
 
-# mise
-if command -v mise >/dev/null 2>&1; then
-	eval "$(mise activate zsh)"
-	eval "$(mise completion zsh)"
-
-	alias mx="mise x --"
-fi
-
 # zoxide
 if command -v zoxide >/dev/null 2>&1; then
 	eval "$(zoxide init zsh --cmd cd)"
@@ -126,11 +118,6 @@ fi
 # custom statusline
 if [[ -f "$ZDOTDIR/statusline.zsh" ]]; then
 	. "$ZDOTDIR/statusline.zsh"
-fi
-
-# chezmoi
-if command -v chezmoi >/dev/null 2>&1; then
-	eval "$(chezmoi completion zsh)"
 fi
 
 # fzf+ghq+gwq

--- a/home/dot_zshenv
+++ b/home/dot_zshenv
@@ -12,8 +12,6 @@ export XDG_RUNTIME_DIR="/tmp"
 # zsh
 export ZDOTDIR="${XDG_CONFIG_HOME}/zsh"
 
-# mise
-export PATH="$HOME/.local/bin:$PATH"
 
 # EDITOR
 export EDITOR="vim"
@@ -21,7 +19,4 @@ export EDITOR="vim"
 # starship
 export STARSHIP_CONFIG="${XDG_CONFIG_HOME}/starship.toml"
 
-# mise
-if command -v mise >/dev/null 2>&1; then
-	eval "$(mise activate zsh)"
 fi

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -1,0 +1,63 @@
+{ config, pkgs, lib, isWSL ? false, ... }:
+{
+  home.stateVersion = "24.11";
+
+  home.sessionVariables = {
+    LANG = "ja_JP.UTF-8";
+    LC_ALL = "ja_JP.UTF-8";
+    EDITOR = "nvim";
+    PAGER = "bat";
+    XDG_CONFIG_HOME = "${config.home.homeDirectory}/.config";
+    XDG_CACHE_HOME = "${config.home.homeDirectory}/.cache";
+    XDG_DATA_HOME = "${config.home.homeDirectory}/.local/share";
+    XDG_STATE_HOME = "${config.home.homeDirectory}/.local/state";
+    STARSHIP_CONFIG = "${config.home.homeDirectory}/.config/starship.toml";
+    ZDOTDIR = "${config.home.homeDirectory}/.config/zsh";
+  };
+
+  home.packages = with pkgs; [
+    usage
+    fzf
+    ghq
+    eza
+    bat
+    ripgrep
+    delta
+    starship
+    neovim
+    lazygit
+    zellij
+    atuin
+    shfmt
+    go
+    nodejs_24
+    deno
+    glab
+    gh
+    zoxide
+  ] ++ lib.optionals (!isWSL) [ ];
+
+  programs.home-manager.enable = true;
+  programs.git.enable = true;
+  programs.starship.enable = true;
+  programs.zoxide.enable = true;
+  programs.fzf.enable = true;
+  programs.atuin.enable = true;
+
+  home.file = {
+    ".config/nvim".source = ../../home/dot_config/nvim;
+    ".config/lazygit/config.yml".source = ../../home/dot_config/lazygit/config.yml;
+    ".config/zellij/config.kdl".source = ../../home/dot_config/zellij/config.kdl;
+    ".config/starship.toml".source = ../../home/dot_config/starship.toml;
+    ".config/alacritty/alacritty.toml".source = ../../home/dot_config/alacritty/alacritty.toml;
+    ".config/git/ignore".source = ../../home/dot_config/git/ignore;
+    ".config/ghq/config.yml".source = ../../home/dot_config/ghq/config.yml;
+    ".config/gwq/config.toml".source = ../../home/dot_config/gwq/config.toml;
+    ".config/atuin/config.toml".source = ../../home/dot_config/atuin/config.toml;
+    ".config/zsh/.zprofile".source = ../../home/dot_config/zsh/dot_zprofile;
+    ".config/zsh/statusline.zsh".source = ../../home/dot_config/zsh/statusline.zsh;
+    ".bashrc".source = ../../home/dot_bashrc;
+    ".zshenv".source = ../../home/dot_zshenv;
+    ".vimrc".source = ../../home/dot_vimrc;
+  };
+}

--- a/nix/home/linux.nix
+++ b/nix/home/linux.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+{
+  programs.zsh = {
+    enable = true;
+    dotDir = ".config/zsh";
+  };
+
+  home.file.".config/zsh/.zshrc".source = ../../home/dot_config/zsh/dot_zshrc;
+}


### PR DESCRIPTION
## 概要
- dotfiles管理を `chezmoi + mise` から `Nix + Home Manager` へ一括移行しました。
- 優先対象の WSL Ubuntu / Arch Linux で使える `flake` 構成を追加しました。

## 変更内容
- `flake.nix` を追加し、`homeConfigurations` として `ubuntu` / `arch` を定義
- `nix/home/common.nix` を追加し、CLIツール・ランタイム・環境変数・dotfiles配布を定義
- `nix/home/linux.nix` を追加し、zsh設定の適用を定義
- `README.md` を Nix運用前提の内容へ更新
- zsh/bash初期化から `mise` と `chezmoi` 依存を削除
  - `home/dot_config/zsh/dot_zshrc`
  - `home/dot_zshenv`
  - `home/dot_bashrc`

## 補足
- このPRでは、まず Linux（WSL Ubuntu / Arch）優先で利用可能な構成にしています。
- macOS / NixOSは次段で同一flakeへ拡張できます。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073f9255608326818eaca2c84a82fc)