### PR TITLE
Add Ubuntu Docker-based Home Manager verification flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ chezmoi diff
 chezmoi apply
 mise install
 ```
+
+## Dockerでの検証手順
+
+Ubuntu 24.04 コンテナ上で Home Manager を適用し、主要コマンド・zsh設定の配置をまとめて検証できます。
+
+```sh
+./scripts/test-ubuntu-docker.sh
+```

--- a/docker/ubuntu-home-manager/Dockerfile
+++ b/docker/ubuntu-home-manager/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    xz-utils \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash tester && \
+    echo "tester ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/tester
+
+USER tester
+WORKDIR /workspace/dotfiles
+
+RUN sh <(curl -L https://nixos.org/nix/install) --no-daemon && \
+    mkdir -p /home/tester/.config/nix && \
+    printf 'experimental-features = nix-command flakes\n' > /home/tester/.config/nix/nix.conf
+
+ENV PATH="/home/tester/.nix-profile/bin:/nix/var/nix/profiles/default/bin:$PATH"
+
+CMD ["bash"]

--- a/scripts/test-ubuntu-docker.sh
+++ b/scripts/test-ubuntu-docker.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+IMAGE_NAME="dotfiles-ubuntu-home-manager-test"
+
+printf 'Dockerイメージをビルドします...\n'
+docker build -t "$IMAGE_NAME" -f "$REPO_ROOT/docker/ubuntu-home-manager/Dockerfile" "$REPO_ROOT"
+
+printf 'Home Managerの適用と検証コマンドを実行します...\n'
+docker run --rm -it \
+  -v "$REPO_ROOT:/workspace/dotfiles" \
+  "$IMAGE_NAME" \
+  bash -lc '
+    set -euo pipefail
+    source /home/tester/.nix-profile/etc/profile.d/nix.sh
+
+    nix run home-manager/master -- switch --flake .#ubuntu
+
+    command -v nvim zellij lazygit rg fzf
+    echo "$ZDOTDIR"
+    test "$ZDOTDIR" = "$HOME/.config/zsh"
+    test -f "$HOME/.config/zsh/.zshrc"
+    test -f "$HOME/.config/zsh/.zprofile"
+    test -f "$HOME/.zshenv"
+
+    echo "検証完了: 必須コマンドとzsh設定ファイルを確認しました。"
+  '


### PR DESCRIPTION
### Motivation

- Ubuntu 24.04 コンテナ上でリポジトリの Home Manager 構成を素早く検証するためのワンコマンド検証フローを追加するため。  
- Nix の `flakes` と `nix-command` を有効化した環境で `nix run home-manager/master -- switch --flake .#ubuntu` を実行して、主要ツールと zsh の設定配置を確認するため。

### Description

- `docker/ubuntu-home-manager/Dockerfile` を追加し、`ubuntu:24.04` ベースで最小パッケージ（`ca-certificates`, `curl`, `git`, `xz-utils`, `sudo`）をインストールし、`tester` ユーザーを作成しています。  
- Dockerfile 内で Nix を `--no-daemon` でインストールし、`/home/tester/.config/nix/nix.conf` に `experimental-features = nix-command flakes` を書き込んでいます。  
- `scripts/test-ubuntu-docker.sh` を追加し、`docker build` → コンテナ起動でリポジトリをマウントして、`source /home/tester/.nix-profile/etc/profile.d/nix.sh` の後に `nix run home-manager/master -- switch --flake .#ubuntu` を実行するワンショット検証を実行します。  
- 検証スクリプト内で `command -v nvim zellij lazygit rg fzf`、`echo $ZDOTDIR` と `test "$ZDOTDIR" = "$HOME/.config/zsh"`、および主要ファイル存在確認（`$HOME/.config/zsh/.zshrc`, `.../.zprofile`, `$HOME/.zshenv`）を行います。  
- `README.md` に「Dockerでの検証手順」を追記し、`./scripts/test-ubuntu-docker.sh` を1コマンドで実行できる旨を記載しました。

### Testing

- `bash -n scripts/test-ubuntu-docker.sh` による構文チェックを実行し、成功しました。  
- スクリプトに実行権限を付与する操作と `git add` / `git commit` を実行し、コミットが正常に作成されることを確認しました。  
- 作成したスクリプトおよび Dockerfile の内容確認（ファイル表示）を行い、意図した変更が反映されていることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0744703b0c83269df21d1d193d3524)